### PR TITLE
feat: adds prefixed logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,9 +198,11 @@ dependencies = [
  "daggy",
  "futures",
  "glob",
+ "log",
  "serde",
  "serde_json",
  "tokio",
+ "urlencoding",
 ]
 
 [[package]]
@@ -534,6 +536,12 @@ name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ clap = { version = "4.0.26", features = ["derive"] }
 daggy = "0.8.0"
 futures = "0.3.25"
 glob = "0.3.0"
+log = "0.4.17"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.88"
 tokio = { version = "1.22.0", features = ["full", "process"] }
+urlencoding = "2.1.2"

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,26 @@
+use log::{Level, LevelFilter, Metadata, Record};
+
+static LOGGER: HastyLogger = HastyLogger;
+
+pub struct HastyLogger;
+
+impl log::Log for HastyLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= Level::Info
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            // ref: https://doc.rust-lang.org/std/fmt/#fillalignment
+            println!("{} - {}", format!("{:<12}", record.target()), record.args());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+pub fn init() {
+    log::set_logger(&LOGGER)
+        .map(|()| log::set_max_level(LevelFilter::Info))
+        .unwrap();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,13 @@
 use clap::Parser;
-use hasty::{self, make_script_id, Engine, Script, TOPOLOGICAL_DEP_PREFIX};
+use hasty::{self, logger, make_script_id, Engine, Script};
 
 #[tokio::main]
 async fn main() {
+    logger::init();
+
     let options = hasty::options::HastyOptions::parse();
 
     if let Some(ref dir) = options.dir {
-        println!("dir: {}", dir.display());
-
         let config = hasty::load_config_file(&options);
 
         let opts_script = match options.script {
@@ -63,6 +63,6 @@ async fn main() {
         // populate graph dependencies
         engine.add_deps_to_graph();
 
-        engine.execute().await;
+        engine.execute(options.dry_run).await;
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -7,10 +7,14 @@ use serde::Deserialize;
 #[clap(author, version, about, long_about = None)]
 #[derive(Deserialize)]
 pub struct HastyOptions {
-    // The directory of the project
+    /// The directory of the project
     #[arg(short, long)]
     pub dir: Option<PathBuf>,
 
-    // The script to execute
+    /// Whether or the script should actually be executed
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// The script to execute
     pub script: Option<String>,
 }


### PR DESCRIPTION
Example output:
```
b#format     - 
b#format     - > format
b#format     - > echo "format:b:start"; sleep 1; echo "format:b:end"
b#format     - 
b#format     - format:b:start
root#format  - 
root#format  - > format
root#format  - > echo "format:start"; sleep 1; echo "format:end"
root#format  - 
root#format  - format:start
a#format     - 
a#format     - > format
a#format     - > echo "format:a:start"; sleep 1; echo "format:a:end"; exit 1
a#format     - 
a#format     - format:a:start
b#format     - format:b:end
root#format  - format:end
a#format     - format:a:end
a#format     - npm ERR! Lifecycle script `format` failed with error: 
a#format     - npm ERR! Error: command failed 
a#format     - npm ERR!   in workspace: a 
a#format     - npm ERR!   at location: /home/bryce/code/hasty/test/basic/packages/a 
b#build      - 
b#build      - > build
b#build      - > echo "build:b:start"; sleep 1; echo "build:b:end"
b#build      - 
root#build   - 
root#build   - > build
root#build   - > echo "build"
root#build   - 
b#build      - build:b:start
root#build   - build
b#build      - build:b:end
a#build      - 
a#build      - > build
a#build      - > echo "build:a:start"; sleep 1; echo "build:a:end"
a#build      - 
a#build      - build:a:start
a#build      - build:a:end
finished in: 4
```

Adds a `--dry-run` flag that runs through building the task graph, but doesn't execute any scripts. It outputs a URL to the visualized task graph instead.